### PR TITLE
ci: add `dependabot` configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+    - package-ecosystem: "gomod"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"


### PR DESCRIPTION
# Motivation

To avoid having to manually update dependencies,
we can use `Dependabot` to automatically create
pull requests when new versions of dependencies
are available.

The config file added in this commit enables
`Dependabot` to manage the dependencies for `go`,
`Github-actions` and `docker`.