### PR TITLE
ci: remove unnecessary `GitHub Actions` triggers

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,6 @@ name: github pages
 
 on:
   push:
-  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: golangci-lint
 
 on:
-  pull_request:
   push:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: test
 
 on:
-  pull_request:
   push:
 
 jobs:


### PR DESCRIPTION
This commit reduces the clutter when viewing pull
requests, as we have less builds to look at.

When triggers for both `push` and `pull_request`
are defined, the `pull_request` trigger is
redundant and can be removed.