### PR TITLE
docs: update required version of `go`

### DIFF
--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -5,7 +5,7 @@ weight: 50
 
 ## Getting Started
 
-Warchaeology is written in [go](https://go.dev) and at least v1.16 should be installed.
+Warchaeology is written in [go](https://go.dev) and requires v1.21 or greater to build.
 
 #### Clone the repository
 ``` sh


### PR DESCRIPTION
The required version of `go` is now 1.21. This was found by running `go test ./...` and getting the
following error message:

```
internal/hooks/hooks_test.go:23:2: package slices
 is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
FAIL	github.com/nlnwa/warchaeology/internal/
 hooks [setup failed]
```