### PR TITLE
refactor: format imports with `goimports`

### DIFF
--- a/arcreader/arcreader.go
+++ b/arcreader/arcreader.go
@@ -18,6 +18,7 @@ package arcreader
 
 import (
 	"bufio"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/spf13/afero"
 )

--- a/arcreader/unmarshaler.go
+++ b/arcreader/unmarshaler.go
@@ -20,14 +20,15 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/klauspost/compress/gzip"
-	"github.com/nlnwa/gowarc"
-	"github.com/nlnwa/warchaeology/internal"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/klauspost/compress/gzip"
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal"
 )
 
 type unmarshaler struct {

--- a/cmd/aart/aart.go
+++ b/cmd/aart/aart.go
@@ -21,12 +21,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nfnt/resize"
-	"github.com/nlnwa/gowarc"
-	"github.com/nlnwa/warchaeology/internal/filter"
-	"github.com/nlnwa/warchaeology/internal/flag"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"image"
 	"image/color"
 	_ "image/gif"
@@ -35,6 +29,13 @@ import (
 	"io"
 	"os"
 	"strconv"
+
+	"github.com/nfnt/resize"
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/filter"
+	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type conf struct {

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -19,13 +19,14 @@ package cat
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filter"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"strconv"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var completionCmd = &cobra.Command{

--- a/cmd/console/RecordWidget.go
+++ b/cmd/console/RecordWidget.go
@@ -20,11 +20,12 @@ package console
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/awesome-gocui/gocui"
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/spf13/viper"
-	"io"
 )
 
 type RecordWidget struct {

--- a/cmd/console/color.go
+++ b/cmd/console/color.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"fmt"
+
 	"github.com/awesome-gocui/gocui"
 )
 

--- a/cmd/console/console.go
+++ b/cmd/console/console.go
@@ -18,15 +18,16 @@ package console
 
 import (
 	"errors"
-	"github.com/awesome-gocui/gocui"
-	"github.com/nlnwa/gowarc"
-	"github.com/nlnwa/warchaeology/internal/flag"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"time"
+
+	"github.com/awesome-gocui/gocui"
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/spf13/cobra"
 )
 
 func NewCommand() *cobra.Command {

--- a/cmd/console/filter.go
+++ b/cmd/console/filter.go
@@ -2,9 +2,10 @@ package console
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/awesome-gocui/gocui"
 	"github.com/nlnwa/gowarc"
-	"strings"
 )
 
 type recordFilter struct {

--- a/cmd/console/listwidget.go
+++ b/cmd/console/listwidget.go
@@ -19,10 +19,11 @@ package console
 import (
 	"context"
 	"fmt"
-	"github.com/awesome-gocui/gocui"
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/awesome-gocui/gocui"
 )
 
 const (

--- a/cmd/console/records.go
+++ b/cmd/console/records.go
@@ -3,14 +3,15 @@ package console
 import (
 	"context"
 	"fmt"
-	"github.com/awesome-gocui/gocui"
-	"github.com/nlnwa/gowarc"
-	"github.com/nlnwa/warchaeology/internal/flag"
-	"github.com/spf13/viper"
 	"io"
 	"io/fs"
 	"os"
 	"strings"
+
+	"github.com/awesome-gocui/gocui"
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/spf13/viper"
 )
 
 type record struct {

--- a/cmd/convert/arc/arc.go
+++ b/cmd/convert/arc/arc.go
@@ -20,6 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/arcreader"
 	"github.com/nlnwa/warchaeology/internal/cmdversion"
@@ -29,12 +36,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
-	"time"
 )
 
 type conf struct {

--- a/cmd/convert/nedlib/nedlib.go
+++ b/cmd/convert/nedlib/nedlib.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal"
 	"github.com/nlnwa/warchaeology/internal/cmdversion"
@@ -30,11 +36,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
-	"time"
 )
 
 type conf struct {

--- a/cmd/convert/warc/warc.go
+++ b/cmd/convert/warc/warc.go
@@ -21,6 +21,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filewalker"
 	"github.com/nlnwa/warchaeology/internal/flag"
@@ -29,12 +36,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
-	"time"
 )
 
 type conf struct {

--- a/cmd/dedup/codec.go
+++ b/cmd/dedup/codec.go
@@ -1,9 +1,10 @@
 package dedup
 
 import (
-	"github.com/nlnwa/gowarc"
 	"strings"
 	"time"
+
+	"github.com/nlnwa/gowarc"
 )
 
 const (

--- a/cmd/dedup/codec_test.go
+++ b/cmd/dedup/codec_test.go
@@ -17,10 +17,11 @@
 package dedup
 
 import (
-	"github.com/nlnwa/gowarc"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_codec_decode(t *testing.T) {

--- a/cmd/dedup/dedup.go
+++ b/cmd/dedup/dedup.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filewalker"
 	"github.com/nlnwa/warchaeology/internal/filter"
@@ -29,11 +35,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
 )
 
 type conf struct {

--- a/cmd/dedup/digestindex.go
+++ b/cmd/dedup/digestindex.go
@@ -18,13 +18,14 @@ package dedup
 
 import (
 	"fmt"
+	"os"
+	"path"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/nlnwa/warchaeology/internal/utils"
 	"github.com/spf13/viper"
-	"os"
-	"path"
 )
 
 const minIndexDiskFree = 1 * 1024 * 1024

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filewalker"
 	"github.com/nlnwa/warchaeology/internal/filter"
@@ -27,11 +33,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io"
-	"os"
-	"os/signal"
-	"strconv"
-	"syscall"
 )
 
 type conf struct {

--- a/cmd/ls/recordwriter.go
+++ b/cmd/ls/recordwriter.go
@@ -18,13 +18,14 @@ package ls
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal"
 	"github.com/nlnwa/warchaeology/internal/utils"
 	"github.com/nlnwa/whatwg-url/url"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 type RecordWriter struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/nlnwa/warchaeology/cmd/aart"
 	"github.com/nlnwa/warchaeology/cmd/cat"
 	"github.com/nlnwa/warchaeology/cmd/console"
@@ -27,7 +29,6 @@ import (
 	"github.com/nlnwa/warchaeology/internal/config"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // NewCommand returns a new cobra.Command implementing the root command for warc

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -25,13 +25,6 @@ import (
 	_ "crypto/sha512"
 	"errors"
 	"fmt"
-	"github.com/nlnwa/gowarc"
-	"github.com/nlnwa/warchaeology/internal/filewalker"
-	"github.com/nlnwa/warchaeology/internal/flag"
-	"github.com/nlnwa/warchaeology/internal/hooks"
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"hash"
 	"io"
 	"os"
@@ -39,6 +32,14 @@ import (
 	"path"
 	"runtime"
 	"syscall"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/filewalker"
+	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/nlnwa/warchaeology/internal/hooks"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type conf struct {

--- a/hack/release/md_docs.go
+++ b/hack/release/md_docs.go
@@ -19,14 +19,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/nlnwa/warchaeology/cmd"
-	"github.com/spf13/cobra/doc"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/nlnwa/warchaeology/cmd"
+	"github.com/spf13/cobra/doc"
 )
 
 func main() {

--- a/internal/cdx.go
+++ b/internal/cdx.go
@@ -17,8 +17,9 @@
 package internal
 
 import (
-	"github.com/nlnwa/gowarc"
 	"strconv"
+
+	"github.com/nlnwa/gowarc"
 )
 
 type Cdx struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,10 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/kirsle/configdir"
 	"github.com/klauspost/compress/gzip"
 	"github.com/nlnwa/warchaeology/internal/flag"
@@ -27,9 +31,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
-	"time"
 )
 
 func InitConfig(cmd *cobra.Command) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,11 +19,12 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/kirsle/configdir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"testing"
 )
 
 type config struct {

--- a/internal/filewalker/fileindex.go
+++ b/internal/filewalker/fileindex.go
@@ -2,11 +2,12 @@ package filewalker
 
 import (
 	"encoding"
+	"os"
+	"path"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/spf13/viper"
-	"os"
-	"path"
 )
 
 type FileIndex struct {

--- a/internal/filewalker/filewalker.go
+++ b/internal/filewalker/filewalker.go
@@ -5,6 +5,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/klauspost/compress/gzip"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/nlnwa/warchaeology/internal/ftpfs"
@@ -15,12 +22,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/afero/tarfs"
 	"github.com/spf13/viper"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"time"
 )
 
 type FileWalker interface {

--- a/internal/filewalker/filewalker_test.go
+++ b/internal/filewalker/filewalker_test.go
@@ -2,10 +2,11 @@ package filewalker_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/nlnwa/warchaeology/internal/filewalker"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFilewalker_Walk(t *testing.T) {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -18,13 +18,14 @@
 package filter
 
 import (
+	"math"
+	"strconv"
+	"strings"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/nlnwa/warchaeology/internal/utils"
 	"github.com/spf13/viper"
-	"math"
-	"strconv"
-	"strings"
 )
 
 type Filter struct {

--- a/internal/flag/helpers.go
+++ b/internal/flag/helpers.go
@@ -18,8 +18,9 @@
 package flag
 
 import (
-	"github.com/spf13/cobra"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // SuffixCompletionFn can be added set for commands which want to restrict file completion to suffixes set by flag

--- a/internal/ftpfs/file.go
+++ b/internal/ftpfs/file.go
@@ -18,11 +18,12 @@
 package ftpfs
 
 import (
-	"github.com/jackc/puddle"
-	"github.com/jlaffaye/ftp"
 	"io"
 	"os"
 	"syscall"
+
+	"github.com/jackc/puddle"
+	"github.com/jlaffaye/ftp"
 )
 
 type File struct {

--- a/internal/ftpfs/file_info.go
+++ b/internal/ftpfs/file_info.go
@@ -18,10 +18,11 @@
 package ftpfs
 
 import (
-	"github.com/jlaffaye/ftp"
 	"io/fs"
 	"os"
 	"time"
+
+	"github.com/jlaffaye/ftp"
 )
 
 const defaultFileMode = 0o555

--- a/internal/ftpfs/ftp.go
+++ b/internal/ftpfs/ftp.go
@@ -19,12 +19,13 @@ package ftpfs
 
 import (
 	"context"
-	"github.com/jackc/puddle"
-	"github.com/jlaffaye/ftp"
-	"github.com/spf13/afero"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/jackc/puddle"
+	"github.com/jlaffaye/ftp"
+	"github.com/spf13/afero"
 )
 
 // Fs is an implementation of afero.Fs that utilizes functions from the ftp package.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -18,11 +18,12 @@
 package hooks
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenInputFileHook(t *testing.T) {

--- a/internal/ssurt.go
+++ b/internal/ssurt.go
@@ -17,9 +17,10 @@
 package internal
 
 import (
-	"github.com/nlnwa/whatwg-url/url"
 	"net"
 	"strings"
+
+	"github.com/nlnwa/whatwg-url/url"
 )
 
 func SsurtUrl(u *url.Url, includeScheme bool) (string, error) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -19,11 +19,12 @@ package utils
 
 import (
 	"fmt"
-	"github.com/shirou/gopsutil/disk"
-	"github.com/spf13/cast"
 	"os"
 	"strings"
 	"unicode"
+
+	"github.com/shirou/gopsutil/disk"
+	"github.com/spf13/cast"
 )
 
 const BadgerRecommendedMaxFileDescr = 65535

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -18,8 +18,9 @@
 package utils_test
 
 import (
-	"github.com/nlnwa/warchaeology/internal/utils"
 	"testing"
+
+	"github.com/nlnwa/warchaeology/internal/utils"
 )
 
 func TestContainsMatchOnMatching(t *testing.T) {

--- a/internal/warcwriterconfig/config.go
+++ b/internal/warcwriterconfig/config.go
@@ -18,15 +18,16 @@ package warcwriterconfig
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/flag"
 	"github.com/nlnwa/warchaeology/internal/hooks"
 	"github.com/nlnwa/warchaeology/internal/utils"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"sync"
-	"time"
 )
 
 const DefaultDateFormat = "2006-1-2"

--- a/internal/warcwriterconfig/namer.go
+++ b/internal/warcwriterconfig/namer.go
@@ -1,11 +1,12 @@
 package warcwriterconfig
 
 import (
-	"github.com/nlnwa/gowarc"
 	"path"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/nlnwa/gowarc"
 )
 
 func NewIdentityNamer(fromFileName, filePrefix, dir string) gowarc.WarcFileNameGenerator {

--- a/main.go
+++ b/main.go
@@ -18,9 +18,10 @@ limitations under the License.
 package main
 
 import (
+	"runtime"
+
 	"github.com/nlnwa/warchaeology/cmd"
 	"github.com/nlnwa/warchaeology/internal/cmdversion"
-	"runtime"
 )
 
 // Overridden by ldflags

--- a/main_test.go
+++ b/main_test.go
@@ -18,8 +18,9 @@
 package main_test
 
 import (
-	"github.com/nlnwa/warchaeology/cmd"
 	"testing"
+
+	"github.com/nlnwa/warchaeology/cmd"
 )
 
 func TestEmptyCommandPrompt(t *testing.T) {

--- a/nedlibreader/nedlibreader.go
+++ b/nedlibreader/nedlibreader.go
@@ -19,12 +19,13 @@ package nedlibreader
 import (
 	"bufio"
 	"bytes"
-	"github.com/nlnwa/gowarc"
-	"github.com/spf13/afero"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/spf13/afero"
 )
 
 type NedlibReader struct {


### PR DESCRIPTION
This commit simply formats all of the imports with the command: `goimports -w .`