### PR TITLE
refactor: limit the use of viper in packages outside cmd

### DIFF
--- a/cmd/aart/aart.go
+++ b/cmd/aart/aart.go
@@ -63,9 +63,12 @@ func NewCommand() *cobra.Command {
 				c.offset = 0
 			}
 
-			viper.Set(flag.MimeType, []string{"image/gif", "image/jpeg", "image/png"})
-			c.filter = filter.NewFromViper()
-
+			c.filter = filter.New(
+				filter.WithMimeType([]string{"image/gif", "image/jpeg", "image/png"}),
+				filter.WithResponseCode(viper.GetString(flag.ResponseCode)),
+				filter.WithRecordIds(viper.GetStringSlice(flag.RecordId)),
+				filter.WithRecordTypes(viper.GetStringSlice(flag.RecordType)),
+			)
 			readFile(c, fileName)
 			return nil
 		},

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -72,7 +72,12 @@ warc cat -n4 -P file1.warc.gz | feh -`,
 				c.offset = 0
 			}
 
-			c.filter = filter.NewFromViper()
+			c.filter = filter.New(
+				filter.WithMimeType(viper.GetStringSlice(flag.MimeType)),
+				filter.WithResponseCode(viper.GetString(flag.ResponseCode)),
+				filter.WithRecordIds(viper.GetStringSlice(flag.RecordId)),
+				filter.WithRecordTypes(viper.GetStringSlice(flag.RecordType)),
+			)
 
 			if !(c.showWarcHeader || c.showProtocolHeader || c.showPayload) {
 				c.showWarcHeader = true

--- a/cmd/dedup/dedup.go
+++ b/cmd/dedup/dedup.go
@@ -84,7 +84,12 @@ The remaining records are written as is.`,
 			}
 			defer c.digestIndex.Close()
 
-			c.filter = filter.NewFromViper()
+			c.filter = filter.New(
+				filter.WithMimeType(viper.GetStringSlice(flag.MimeType)),
+				filter.WithResponseCode(viper.GetString(flag.ResponseCode)),
+				filter.WithRecordIds(viper.GetStringSlice(flag.RecordId)),
+				filter.WithRecordTypes(viper.GetStringSlice(flag.RecordType)),
+			)
 
 			return runE(cmd.Name(), c)
 		},

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -99,7 +99,12 @@ Output options:
 				viper.Set(flag.LogConsole, []string{"summary"})
 			}
 
-			c.filter = filter.NewFromViper()
+			c.filter = filter.New(
+				filter.WithMimeType(viper.GetStringSlice(flag.MimeType)),
+				filter.WithResponseCode(viper.GetString(flag.ResponseCode)),
+				filter.WithRecordIds(viper.GetStringSlice(flag.RecordId)),
+				filter.WithRecordTypes(viper.GetStringSlice(flag.RecordType)),
+			)
 
 			return runE(cmd.Name(), c)
 		},


### PR DESCRIPTION
Using viper outside command initialization and configuration makes it difficult to see what options gets applied.

This commit refactors the initialization of the Filter struct in the filter package to use functional options over initializing from viper.