### PR TITLE
refactor: separation of arguments and logic

### DIFF
--- a/cmd/aart/aart.go
+++ b/cmd/aart/aart.go
@@ -45,35 +45,37 @@ type conf struct {
 }
 
 func NewCommand() *cobra.Command {
-	c := &conf{}
 	var cmd = &cobra.Command{
 		Use:    "aart",
 		Short:  "Show images",
 		Long:   ``,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return errors.New("missing file name")
-			}
-			fileName := args[0]
-			c.offset = viper.GetInt64(flag.Offset)
-			c.recordNum = viper.GetInt(flag.RecordNum)
-
-			if c.offset < 0 {
-				c.offset = 0
-			}
-
-			viper.Set(flag.MimeType, []string{"image/gif", "image/jpeg", "image/png"})
-			c.filter = filter.NewFromViper()
-
-			readFile(c, fileName)
-			return nil
-		},
-	}
+		RunE:   parseArgumentsAndCallAsciiArt}
 
 	cmd.Flags().IntP("width", "w", 100, "Width of image")
 
 	return cmd
+}
+
+func parseArgumentsAndCallAsciiArt(cmd *cobra.Command, args []string) error {
+	config := &conf{}
+	if len(args) == 0 {
+		return errors.New("missing file name")
+	}
+	fileName := args[0]
+	config.offset = viper.GetInt64(flag.Offset)
+	config.recordNum = viper.GetInt(flag.RecordNum)
+
+	if config.offset < 0 {
+		config.offset = 0
+	}
+
+	viper.Set(flag.MimeType, []string{"image/gif", "image/jpeg", "image/png"})
+	config.filter = filter.NewFromViper()
+
+	readFile(config, fileName)
+	return nil
+
 }
 
 func readFile(c *conf, fileName string) {

--- a/cmd/console/console.go
+++ b/cmd/console/console.go
@@ -32,42 +32,45 @@ import (
 
 func NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "console <directory>",
-		Short: "A shell for working with WARC files",
-		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				state.dir = args[0]
-			}
-			var err error
-			if state.dir, err = filepath.Abs(state.dir); err != nil {
-				return err
-			}
-			if state.dir, err = filepath.EvalSymlinks(state.dir); err != nil {
-				return err
-			}
-			var f os.FileInfo
-			f, err = os.Lstat(state.dir)
-			if err != nil {
-				return err
-			}
-			if !f.IsDir() {
-				f := path.Base(state.dir)
-				state.dir = path.Dir(state.dir)
-				state.files = append(state.files, f)
-			}
-			if state.suffixes, err = cmd.Flags().GetStringSlice(flag.Suffixes); err != nil {
-				return err
-			}
-
-			return runE()
-		},
+		Use:               "console <directory>",
+		Short:             "A shell for working with WARC files",
+		Long:              ``,
+		RunE:              parseArgumentsAndCallConsole,
 		ValidArgsFunction: flag.SuffixCompletionFn,
 	}
 
 	cmd.Flags().StringSlice(flag.Suffixes, []string{".warc", ".warc.gz"}, flag.SuffixesHelp)
 
 	return cmd
+}
+
+func parseArgumentsAndCallConsole(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		state.dir = args[0]
+	}
+	var err error
+	if state.dir, err = filepath.Abs(state.dir); err != nil {
+		return err
+	}
+	if state.dir, err = filepath.EvalSymlinks(state.dir); err != nil {
+		return err
+	}
+	var f os.FileInfo
+	f, err = os.Lstat(state.dir)
+	if err != nil {
+		return err
+	}
+	if !f.IsDir() {
+		f := path.Base(state.dir)
+		state.dir = path.Dir(state.dir)
+		state.files = append(state.files, f)
+	}
+	if state.suffixes, err = cmd.Flags().GetStringSlice(flag.Suffixes); err != nil {
+		return err
+	}
+
+	return runE()
+
 }
 
 var state = &State{curView: "dir"}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -53,29 +53,10 @@ var config conf
 
 func NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "validate <files/dirs>",
-		Short: "Validate warc files",
-		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 && viper.GetString(flag.SrcFileList) == "" {
-				return errors.New("missing file or directory name")
-			}
-			config.files = args
-			config.warcDir = viper.GetString(flag.WarcDir)
-
-			var err error
-			config.openOutputFileHook, err = hooks.NewOpenOutputFileHook(cmd.Name(), viper.GetString(flag.OpenOutputFileHook))
-			if err != nil {
-				return err
-			}
-
-			config.closeOutputFileHook, err = hooks.NewCloseOutputFileHook(cmd.Name(), viper.GetString(flag.CloseOutputFileHook))
-			if err != nil {
-				return err
-			}
-
-			return runE(cmd.Name())
-		},
+		Use:               "validate <files/dirs>",
+		Short:             "Validate warc files",
+		Long:              ``,
+		RunE:              parseArgumentsAndCallValidate,
 		ValidArgsFunction: flag.SuffixCompletionFn,
 	}
 
@@ -101,6 +82,28 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().String(flag.CalculateHash, "", flag.CalculateHashHelp)
 
 	return cmd
+}
+
+func parseArgumentsAndCallValidate(cmd *cobra.Command, args []string) error {
+
+	if len(args) == 0 && viper.GetString(flag.SrcFileList) == "" {
+		return errors.New("missing file or directory name")
+	}
+	config.files = args
+	config.warcDir = viper.GetString(flag.WarcDir)
+
+	var err error
+	config.openOutputFileHook, err = hooks.NewOpenOutputFileHook(cmd.Name(), viper.GetString(flag.OpenOutputFileHook))
+	if err != nil {
+		return err
+	}
+
+	config.closeOutputFileHook, err = hooks.NewCloseOutputFileHook(cmd.Name(), viper.GetString(flag.CloseOutputFileHook))
+	if err != nil {
+		return err
+	}
+
+	return runE(cmd.Name())
 }
 
 func runE(cmd string) error {


### PR DESCRIPTION
# Motivation

To increase readability and testability,
separating the command line arguments from the
business logic is a good idea.

As a step in this direction, this commit creates
new functions for handling the arguments, even if
all argument handling is not done in these
functions just yet.

Follow up commits will further make this
separation clearer.