### PR TITLE
ci: enable `goimports` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,7 +42,6 @@ linters:
     - godox
     - goerr113
     - gofumpt
-    - goimports
     - golint
     - gomnd
     - gosec


### PR DESCRIPTION
This commit ensures that imports are consistently
formatted across the project.

All files were previously formatted with
`goimports`, in commit
6f6b515193623671dc75a398c867f9d8aa810877.