### PR TITLE
fix: replace deprecated `goreleaser` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.18.2
-          args: release --rm-dist ${{ env.flags }}
+          args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The following error inspired this commit:

```
• DEPRECATED: --rm-dist was deprecated in favor of
--clean, check
https://goreleaser.com/deprecations#-rm-dist for
more details
```

The actual fix was simply doing as the error
message suggested.