### PR TITLE
ci: store artifacts after build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,40 @@ jobs:
           args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # This should have been a matrix, but building separate targets is a paid feature in `goreleaser`
+      - uses: actions/upload-artifact@v4
+        with:
+          name: darwin-x86_64
+          path: dist/warchaeology_Darwin_x86_64*.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-x86_64
+          path: dist/warchaeology_Linux_x86_64.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-i386
+          path: dist/warchaeology_Linux_i386.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64
+          path: dist/warchaeology_Windows_x86_64.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-i386
+          path: dist/warchaeology_Windows_i386.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb-amd64
+          path: dist/warchaeology_*amd64.deb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb-i386
+          path: dist/warchaeology_*i386.deb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm-x86_64
+          path: dist/warchaeology-*x86_64.rpm
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm-i386
+          path: dist/warchaeology-*i386.rpm


### PR DESCRIPTION
# Motivation

To be able to build and release more automatic and less dependent on the local environment, we need
to store the build artifacts in a place where we
can access them later.

# Changes

Stores some of the build artifacts from the `dist` directory after a successful build.

# Future work

Use these artifacts to create a release together
with autogenerated docs.

# Quirks

Ideally the artifacts should be built in a
separate job to avoid potential contamination of
the build environment. But because this is a paid
`gorelease` feature we will just have to continue
building all targets in one go.