### PR TITLE
fix: remove deprecated `replacements`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,11 +72,6 @@ nfpms:
         dst: /usr/share/doc/warc/copyright
         file_info:
           mode: 0644
-    overrides:
-      rpm:
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
# Motivation

This commit solves the following warning which is
blocking us from upgrading `goreleaser` to a newer version:

```
• DEPRECATED: `nfpms.replacements` should not be
used anymore, check
https://goreleaser.com/deprecations#nfpmsreplacements
for more info
```

# Changes

The fix was simply to remove it, it seems like it
was relevant in commit
b765ea8657fba82ab8cdc69bf4d7bbe4ad812863 when it
was used for changing the file name. But it became dead code after commit
358436f354446a34495158698ca85b65057d6500

# Future work

If we truly want to support the distributions that we provide artifacts for, we need automatic
testing.