### PR TITLE
fix: remove deprecated `archives.rlcp`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,6 @@ archives:
     builds_info:
       group: root
       owner: root
-    rlcp: true
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
This commit fixes the following warning:
```
• DEPRECATED: archives.rlcp should not be used
anymore, check
https://goreleaser.com/deprecations#archivesrlcp
for more info
```