### PR TITLE
fix: silence output when running `go test`

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,17 @@
 package main_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/nlnwa/warchaeology/cmd"
 )
 
 func TestEmptyCommandPrompt(t *testing.T) {
+	os.Stdout = nil
+	os.Stderr = nil
+
 	shell := cmd.NewCommand()
 	_ = shell.Execute()
+
 }


### PR DESCRIPTION
This commit fixes the issue where running `go
test` would write to stdout. This was caused by
commit 0c94a34011af2c7135fbae6598abc8790e087a25.

The solution is just to redirect `stdout` and
`stderr` to `nil`.

Solves https://github.com/nlnwa/warchaeology/issues/87