### PR TITLE
ci: push benchmark results to dedicated branch

### DIFF
--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -39,3 +41,45 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: true
           alert-threshold: "150%"
+
+      - name: Create benchmark result directory
+        run: mkdir --parents benchmarks/${{ matrix.os }}/
+      - name: Create benchmark results json
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'go'
+          output-file-path: benchmark-result.txt
+          external-data-json-path: benchmarks/${{ matrix.os }}/results.json
+          auto-push: false
+          fail-on-alert: true
+          alert-threshold: "150%"
+      - name: Upload artifact for benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-benchmark-results
+          path: benchmarks/${{ matrix.os }}/results.json
+      - name: Code Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: benchmark-results
+      - name: Download artifact for previous benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.os }}-benchmark-results
+          path: benchmarks/${{ matrix.os }}/
+      - name: Commit and push benchmark results
+        uses: EndBug/add-and-commit@v9
+        id: commit-and-push
+        with:
+          add: "benchmarks"
+          message: 'chore: update benchmark results'
+          new_branch: benchmark-results
+          pathspec_error_handling: exitImmediately
+          push: true
+      - name: Verify that a commit has been pushed
+        run: |
+          if [ "${{ steps.commit-and-push.outputs.pushed }}" != "true" ]; then
+            echo "Commit failed"
+            exit 1
+          fi


### PR DESCRIPTION
# Motivation

The current benchmarking system does not compare
the results with previous benchmarks, as we have
no place to store the results.

This commit ensures that this is no longer the
case by pushing the benchmark results to a
dedicated branch called `benchmark-results`.

# Changes

After pushing the benchmark results to `GitHub
pages`, a json is now created and automatically
committed to the `benchmark-results` branch.

# Rejected alternatives

Use `actions/cache` to store the results. The
reason why this was not done is that the entries
in the cache will expire after a set amount of
time, which is likely to happen. In such a
scenario there will be additional burdens on the
developers to manually update the cache.

# Quirks

The benchmark results had to be moved out of the
working directory because of conflicts with the
checkout actions.