### PR TITLE
ci: compare with previous benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,16 +52,15 @@ jobs:
         with:
           name: ${{ matrix.os }}-benchmark-results
           path: benchmark-result.txt
-      # TODO: immediately after merging this, the following code should be
-      # replaced by downloading the previous benchmark results instead
-      - name: make dummy dir
-        run: mkdir --parents ./previous/benchmarks/${{ matrix.os }}/
-      - name: create dummy file
-        run: echo ' ' > ./previous/benchmarks/${{ matrix.os }}/results.json
+      - name: Download previous benchmark results
+        uses: actions/checkout@v4
+        with:
+          ref: benchmark-results
+          path: previous/
       - name: Compare benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Benchmarks
+          name: Go Benchmark
           tool: 'go'
           output-file-path: benchmark-result.txt
           external-data-json-path: ./previous/benchmarks/${{ matrix.os }}/results.json


### PR DESCRIPTION
# Motivation

The previous commits of
343fb0a3b0d48856cb1af9237c43d0601f728a63 and
8f539bf9177c182a8d600cea02076538fc95a048 added
creation and storage of benchmark results.

This commit now does the final stage which is to
compare the new benchmark results with the
previous results.

# Changes

Renamed the benchmark name to `Go Benchmark` so
that it matches the benchmark name uploaded by
`publish_benchmarks.yml`, otherwise the comparison will never work.

Use download previous benchmarks from the
dedicated `benchmark-results` branch.