### PR TITLE
Revert "ci: enable benchmarking for MacOS"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     name: Benchmark
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     name: Publish benchmark results
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Code Checkout


### PR DESCRIPTION
This reverts commit 99cda7ca342e449875e6b44db08292a0264eb5f9.

The reason for this revert is that publishing the
benchmark results failed with the following error:

```
Run mkdir --parents benchmarks/macos-13/
mkdir --parents benchmarks/macos-13/
shell: /bin/bash -e {0}
mkdir: illegal option -- -
usage: mkdir [-pv] [-m mode] directory_name ...
Process completed with exit code 64.
```