### PR TITLE
Revert "ci: enable benchmarking for windows"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     name: Benchmark
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     name: Publish benchmark results
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Code Checkout


### PR DESCRIPTION
This reverts commit 4356a8f0d0148835b87cd8463f2b8e9b82a078a5.

The reason for this revert is that publishing the
benchmark results failed with the following error:

```
mkdir: D:\a\_temp\7b514a37-675e-4b59-90db-e2c0e048869e.ps1:2
Line |
   2 |  mkdir --parents benchmarks/windows-2022/
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | A positional parameter cannot be found that
accepts argument 'benchmarks/windows-2022/'.
Error: Process completed with exit code 1.
```