### PR TITLE
fix: add error handling to `workerPool`

### DIFF
--- a/internal/workerpool/workerpool.go
+++ b/internal/workerpool/workerpool.go
@@ -7,7 +7,8 @@ import (
 
 type workerPool struct {
 	numberOfWorkers int
-	jobs            chan func()
+	jobs            chan func() error
+	errors          chan error
 	waitGroup       sync.WaitGroup
 }
 
@@ -15,16 +16,20 @@ func New(ctx context.Context, numberOfWorkers int) *workerPool {
 	magicNumber := 4
 	pool := &workerPool{
 		numberOfWorkers: numberOfWorkers,
-		jobs:            make(chan func(), numberOfWorkers*magicNumber),
+		jobs:            make(chan func() error, numberOfWorkers*magicNumber),
+		errors:          make(chan error, numberOfWorkers*magicNumber),
 		waitGroup:       sync.WaitGroup{},
 	}
 	for workerIndex := 0; workerIndex < numberOfWorkers; workerIndex++ {
-		go func(jobs <-chan func()) {
+		go func(jobs <-chan func() error) {
 			for job := range jobs {
 				select {
 				case <-ctx.Done():
 				default:
-					job()
+					err := job()
+					if err != nil {
+						pool.errors <- err
+					}
 				}
 				pool.waitGroup.Done()
 			}
@@ -33,12 +38,19 @@ func New(ctx context.Context, numberOfWorkers int) *workerPool {
 	return pool
 }
 
-func (pool *workerPool) CloseWait() {
-	close(pool.jobs)
+func (pool *workerPool) CloseWait() error {
 	pool.waitGroup.Wait()
+	close(pool.jobs)
+	close(pool.errors)
+	for err := range pool.errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func (pool *workerPool) Submit(job func()) {
+func (pool *workerPool) Submit(job func() error) {
 	pool.waitGroup.Add(1)
 	pool.jobs <- job
 }


### PR DESCRIPTION
# Motivation

The functions submitted to `workerPool` might
fail, and the errors they return should be
properly propagated.

# Changes

To propagate the errors to the main goroutine, a
channel is used to transfer the errors. When
closing the `workerPool` any errors transferred
will be evaluated and if there is any none-nil
errors, the first one will be returned.

# Quirks

This commit also disables the sub-linter `gocyclo` for a function in `filewalker.go` as it is the
refactoring triggered by this commit increase the
complexity.

This complexity is only intermediate and will be
removed upon further refactoring.

The original linter error was the following:
```
lint: internal/filewalker/filewalker.go#L192
cyclomatic complexity 31 of func `(*fileWalker).Walk`
is high (> 30) (gocyclo)
```