### PR TITLE
test: add simplest test for `ls`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.warc.gz filter=lfs diff=lfs merge=lfs -text

--- a/cmd/ls/ls_test.go
+++ b/cmd/ls/ls_test.go
@@ -1,0 +1,19 @@
+package ls
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nlnwa/warchaeology/internal/filter"
+	"github.com/spf13/afero"
+)
+
+func TestConfigReadFileWithError(t *testing.T) {
+	testDataDir := filepath.Join("..", "..", "test-data")
+	warcWithErrors := filepath.Join(testDataDir, "samsung-with-error", "rec-33318048d933-20240317162652059-0.warc.gz")
+	config := &conf{}
+	config.filter = filter.NewFromViper()
+	config.files = []string{warcWithErrors}
+	_ = config.readFile(afero.NewOsFs(), warcWithErrors)
+	// TODO: check that the result contains the expected values
+}

--- a/test-data/samsung-with-error/README.md
+++ b/test-data/samsung-with-error/README.md
@@ -1,0 +1,3 @@
+# Origin
+
+This file was provided by Ilya Kreymer through issue: https://github.com/nlnwa/warchaeology/issues/99#issuecomment-2012776966

--- a/test-data/samsung-with-error/rec-33318048d933-20240317162652059-0.warc.gz
+++ b/test-data/samsung-with-error/rec-33318048d933-20240317162652059-0.warc.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d2546af6d8e2ae9cd091e780f4110c0d8302d1542d1a3d001b99de9659e72d2
+size 505729


### PR DESCRIPTION
# Motivation

Many top level commands are missing tests. This is a first step to add a test for `ls` with proper
test data.

# Changes

This commit adds a very simple test for `ls` that
checks that it does not crash when reading a file.

# Future work

Add more checks to the test so that it is even
better at avoiding regressions.

# Acknowledgements

Thanks to Ilya Kreymer for providing the test data through issue
https://github.com/nlnwa/warchaeology/issues/99