### PR TITLE
ci: enable windows benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     name: Benchmark
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_benchmarks.yml
+++ b/.github/workflows/publish_benchmarks.yml
@@ -12,23 +12,33 @@ permissions:
   # contents permission to update benchmark contents in gh-pages branch
   contents: write
 
+env:
+  DEFAULT_BRANCH: main
+
 jobs:
   publish-benchmarks:
     name: Publish benchmark results
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
+    concurrency:
+        group: push-to-benchmark-branch
+        cancel-in-progress: false
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.DEFAULT_BRANCH }}
           lfs: true
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run benchmarks
         run: go test ./... -bench="Bench" | tee benchmark-result.txt
       - name: Publish benchmark results
@@ -44,7 +54,7 @@ jobs:
           alert-threshold: "150%"
 
       - name: Create benchmark result directory
-        run: mkdir --parents benchmarks/${{ matrix.os }}/
+        run: python continuous-integration/create_dir.py --path benchmarks/${{ matrix.os }}/
       - name: Create benchmark results json
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -79,9 +89,9 @@ jobs:
           new_branch: benchmark-results
           pathspec_error_handling: exitImmediately
           push: true
+      - name: Code Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
       - name: Verify that a commit has been pushed
-        run: |
-          if [ "${{ steps.commit-and-push.outputs.pushed }}" != "true" ]; then
-            echo "Commit failed"
-            exit 1
-          fi
+        run: python continuous-integration/check_push_status.py --push-status "${{ steps.commit-and-push.outputs.pushed }}"

--- a/continuous-integration/check_push_status.py
+++ b/continuous-integration/check_push_status.py
@@ -1,0 +1,23 @@
+import sys
+from argparse import ArgumentParser, Namespace
+
+
+def _args() -> Namespace:
+    parser = ArgumentParser()
+    parser.add_argument("--push-status", type=str, required=True)
+    return parser.parse_args()
+
+
+def _main():
+    push_status = _args().push_status
+    print("Checking push status")
+    if push_status == "true":
+        print("Commit has been pushed successfully")
+        sys.exit(0)
+    else:
+        print("Commit has not been pushed successfully")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _main()

--- a/continuous-integration/create_dir.py
+++ b/continuous-integration/create_dir.py
@@ -1,0 +1,18 @@
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+
+def _args() -> Namespace:
+    parser = ArgumentParser()
+    parser.add_argument("--path", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _main():
+    path = _args().path
+    print(f"Creating directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
This commit is not quite a revert of commit
a91ef1303089616d253cd508783f429e3d2a85d9, but it
is close. The main difference is that this commit
handles the creation of the directories and
verification of the `push` status in an OS
agnostic way.

To avoid race conditions, each of the benchmark
jobs are now running one at a time, otherwise
there might be upload collision.