### PR TITLE
fix: silence benchmark output

### DIFF
--- a/cmd/ls/ls_test.go
+++ b/cmd/ls/ls_test.go
@@ -1,6 +1,7 @@
 package ls
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,6 +20,10 @@ func TestConfigReadFileWithError(t *testing.T) {
 }
 
 func BenchmarkReadFileWithError(b *testing.B) {
+	// Stdout is redirected to /dev/null since the benchmarking tool
+	// `github-action-benchmark` is unable to handle some of the output in the
+	// benchmark result files.
+	os.Stdout = nil
 	testDataDir := filepath.Join("..", "..", "test-data")
 	warcWithErrors := filepath.Join(testDataDir, "samsung-with-error", "rec-33318048d933-20240317162652059-0.warc.gz")
 	config := &conf{}


### PR DESCRIPTION
Since commit
d8d316a6707a8f3e2234e5c483250ab7b99943de the
benchmark results of `BenchmarkReadFileWithError`
are no longer present.
`BenchmarkReadFileWithError` has not been deleted, and it seems like some of the output printed to
the benchmark result file causes
`github-action-benchmark` to fail finding this
result.

The reason why commit
d8d316a6707a8f3e2234e5c483250ab7b99943de triggered this error is because it added the required `lfs`
checkout so that the test-data was cloned
correctly.

As a workaround, this commit silences the output
of the benchmark `BenchmarkReadFileWithError`.