### PR TITLE
feat: WARC record iterator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 testdata/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5 filter=lfs diff=lfs merge=lfs -text
 testdata/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5 filter=lfs diff=lfs merge=lfs -text
 *.meta filter=lfs diff=lfs merge=lfs -text
+*.warc filter=lfs diff=lfs merge=lfs -text

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -1,14 +1,15 @@
 package cat
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filter"
 	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/nlnwa/warchaeology/internal/warc"
 	"github.com/spf13/viper"
 )
 
@@ -23,100 +24,97 @@ type config struct {
 	showPayload        bool
 }
 
-func listRecords(catConfig *config, fileName string) {
-	warcFileReader, err := gowarc.NewWarcFileReader(fileName, catConfig.offset, gowarc.WithBufferTmpDir(viper.GetString(flag.TmpDir)))
-	defer func() { _ = warcFileReader.Close() }()
+func runCat(catConfig *config) error {
+	warcFileReader, err := gowarc.NewWarcFileReader(catConfig.fileName, catConfig.offset, gowarc.WithBufferTmpDir(viper.GetString(flag.TmpDir)))
 	if err != nil {
-		fmt.Printf("Error opening file: %v\n", err)
-		return
+		return fmt.Errorf("error opening file: %w", err)
 	}
 
-	num := 0
-	count := 0
+	defer func() { _ = warcFileReader.Close() }()
 
-	for {
-		warcRecord, _, _, err := warcFileReader.Next()
-		if err == io.EOF {
-			break
+	records := make(chan warc.Record)
+
+	iterator := warc.Iterator{
+		WarcFileReader: warcFileReader,
+		Filter:         catConfig.filter,
+		Nth:            catConfig.recordNum,
+		Limit:          catConfig.recordCount,
+		Records:        records,
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	go iterator.Iterate(ctx)
+
+	for record := range records {
+		if record.Err != nil {
+			return fmt.Errorf("error in record at offset %v: %w", record.Offset, record.Err)
 		}
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %v, rec num: %v, Offset %v\n", err.Error(), strconv.Itoa(count), catConfig.offset)
-			break
-		}
-
-		if !catConfig.filter.Accept(warcRecord) {
-			continue
-		}
-
-		// Find record number
-		if catConfig.recordNum > 0 && num < catConfig.recordNum {
-			num++
-			continue
-		}
-
-		count++
-		out := os.Stdout
-
-		if catConfig.showWarcHeader {
-			// Write WARC record version
-			_, err = fmt.Fprintf(out, "%v\r\n", warcRecord.Version())
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-
-			// Write WARC header
-			_, err = warcRecord.WarcHeader().Write(out)
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-
-			// Write separator
-			_, err = out.WriteString("\r\n")
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-		}
-
-		if catConfig.showProtocolHeader {
-			if headerBlock, ok := warcRecord.Block().(gowarc.ProtocolHeaderBlock); ok {
-				_, err = out.Write(headerBlock.ProtocolHeaderBytes())
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			}
-		}
-
-		if catConfig.showPayload {
-			if payloadBlock, ok := warcRecord.Block().(gowarc.PayloadBlock); ok {
-				reader, err := payloadBlock.PayloadBytes()
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-				_, err = io.Copy(out, reader)
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			} else {
-				reader, err := warcRecord.Block().RawBytes()
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-				_, err = io.Copy(out, reader)
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			}
-		}
-
-		// Write end of record separator
-		_, err = out.WriteString("\r\n\r\n")
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-		}
-
-		if catConfig.recordCount > 0 && count >= catConfig.recordCount {
-			break
+		if err := writeWarcRecord(os.Stdout, record.WarcRecord, catConfig); err != nil {
+			return err
 		}
 	}
-	_, _ = fmt.Fprintln(os.Stderr, "Count: ", count)
+	return nil
+}
+
+func writeWarcRecord(out io.Writer, warcRecord gowarc.WarcRecord, catConfig *config) error {
+	if catConfig.showWarcHeader {
+		// Write WARC record version
+		_, err := fmt.Fprintf(out, "%v\r\n", warcRecord.Version())
+		if err != nil {
+			return fmt.Errorf("error writing WARC record version: %w", err)
+		}
+
+		// Write WARC header
+		_, err = warcRecord.WarcHeader().Write(out)
+		if err != nil {
+			return fmt.Errorf("error writing WARC header: %w", err)
+		}
+
+		// Write newline
+		_, err = out.Write([]byte("\r\n"))
+		if err != nil {
+			return fmt.Errorf("error writing separator: %w", err)
+		}
+	}
+
+	if catConfig.showProtocolHeader {
+		if headerBlock, ok := warcRecord.Block().(gowarc.ProtocolHeaderBlock); ok {
+			_, err := out.Write(headerBlock.ProtocolHeaderBytes())
+			if err != nil {
+				return fmt.Errorf("error writing protocol header: %w", err)
+			}
+		}
+	}
+
+	if catConfig.showPayload {
+		if payloadBlock, ok := warcRecord.Block().(gowarc.PayloadBlock); ok {
+			reader, err := payloadBlock.PayloadBytes()
+			if err != nil {
+				return fmt.Errorf("error reading payload: %w", err)
+			}
+			_, err = io.Copy(out, reader)
+			if err != nil {
+				return fmt.Errorf("error writing payload: %w", err)
+			}
+		} else {
+			reader, err := warcRecord.Block().RawBytes()
+			if err != nil {
+				return fmt.Errorf("error reading raw bytes of record block: %w", err)
+			}
+			_, err = io.Copy(out, reader)
+			if err != nil {
+				return fmt.Errorf("error writing raw bytes of record block: %w", err)
+			}
+		}
+	}
+
+	// Write end of record separator
+	_, err := out.Write([]byte("\r\n\r\n"))
+	if err != nil {
+		return fmt.Errorf("error writing end of record separator: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -1,9 +1,167 @@
 package cat
 
 import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/warc"
 )
+
+const (
+	testDataDir = "../../testdata"
+)
+
+var testFiles = map[string]string{
+	"empty":              filepath.Join(testDataDir, "empty.warc"),
+	"single-record":      filepath.Join(testDataDir, "single-record.warc"),
+	"samsung-with-error": filepath.Join(testDataDir, "samsung-with-error", "rec-33318048d933-20240317162652059-0.warc.gz"),
+}
+
+// TestWriteWarcRecord tests the writeWarcRecord function.
+func TestWriteWarcRecord(t *testing.T) {
+	for name, testFile := range testFiles {
+		t.Run(name, func(t *testing.T) {
+			// capture testFile variable from outer scope
+			testFile := testFile
+
+			// resolve test file path
+			testFile, err := filepath.Abs(testFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var want []byte
+			var warcFileReader *gowarc.WarcFileReader
+
+			if filepath.Ext(testFile) == ".gz" {
+				f, err := os.Open(testFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer f.Close()
+
+				gzipReader, err := gzip.NewReader(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer gzipReader.Close()
+				count := 0
+				for {
+					// Read bytes from the bufio reader
+					buffer := make([]byte, 1024)
+					n, err := gzipReader.Read(buffer)
+					if err != nil {
+						if err == io.EOF {
+							break
+						} else {
+							want = append(want, buffer[:n]...)
+							break
+						}
+					}
+					count += n
+
+					want = append(want, buffer[:n]...)
+				}
+
+				_, err = f.Seek(0, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = gzipReader.Reset(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// read uncompressed WARC file to get uncompressed offset
+				warcFileReader, err = gowarc.NewWarcFileReaderFromStream(gzipReader, 0, gowarc.WithAddMissingDigest(false))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					_ = warcFileReader.Close()
+				}()
+			} else {
+				// open WARC file reader
+				warcFileReader, err = gowarc.NewWarcFileReader(testFile, 0, gowarc.WithAddMissingDigest(false))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					_ = warcFileReader.Close()
+				}()
+
+				want, err = os.ReadFile(testFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			records := make(chan warc.Record)
+
+			go warc.Iterator{
+				WarcFileReader: warcFileReader,
+				Records:        records,
+			}.Iterate(context.Background())
+
+			// print everything
+			catConfig := &config{
+				showWarcHeader:     true,
+				showProtocolHeader: true,
+				showPayload:        true,
+			}
+
+			got := new(bytes.Buffer)
+			var currentOffset int64
+
+			for record := range records {
+				if record.Err != nil {
+					break
+				}
+
+				err := writeWarcRecord(got, record.WarcRecord, catConfig)
+				if err != nil {
+					t.Errorf("writeWarcRecord() error = %v", err)
+				}
+
+				currentOffset = record.Offset + record.Size
+			}
+
+			want = want[:currentOffset]
+
+			var n = 10
+			for math.Min(float64(len(got.Bytes())), float64(len(want))) < float64(n) {
+				n--
+			}
+
+			if !bytes.Equal(got.Bytes(), want) {
+				t.Errorf(`writeWarcRecord() = want != got
+want is %d bytes, got is %d bytes
+	-- first bytes of want: --
+%v
+	-- first bytes of got: --
+%v
+	-- last bytes of want: --
+%v
+	-- last bytes of got: --
+%v
+`,
+					len(want), len(got.Bytes()),
+					want[:n],
+					got.Bytes()[:n],
+					want[len(want)-n:],
+					got.Bytes()[len(got.Bytes())-n:])
+			}
+		})
+	}
+}
 
 func BenchmarkDummy(b *testing.B) {
 	// This is a dummy test, it should be replaced with something more

--- a/cmd/cat/cli.go
+++ b/cmd/cat/cli.go
@@ -64,6 +64,9 @@ func parseArgumentsAndCallCat(cmd *cobra.Command, args []string) error {
 		catConfig.showProtocolHeader = true
 		catConfig.showPayload = true
 	}
-	listRecords(catConfig, catConfig.fileName)
-	return nil
+
+	// Silence usage to avoid printing usage when an error occurs
+	cmd.SilenceUsage = true
+
+	return runCat(catConfig)
 }

--- a/internal/warc/iterator.go
+++ b/internal/warc/iterator.go
@@ -1,0 +1,124 @@
+package warc
+
+import (
+	"context"
+	"io"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/filter"
+)
+
+// Record represents a WARC record with additional metadata
+type Record struct {
+	Offset     int64
+	Size       int64
+	Err        error
+	WarcRecord gowarc.WarcRecord
+	Validation *gowarc.Validation
+}
+
+// Itetaror is a WARC record iterator
+type Iterator struct {
+	// reader to read WARC records from
+	WarcFileReader *gowarc.WarcFileReader
+
+	// return only the Nth record (0 for all) after applying filter
+	Nth int
+
+	// return at most N records (0 for all) after applying filter
+	Limit int
+
+	// return only records that match the filter
+	Filter *filter.Filter
+
+	// channel to send records to
+	Records chan<- Record
+}
+
+// Iterate reads WARC records from the WARC file reader and sends them to the result channel
+func (iterator Iterator) Iterate(ctx context.Context) {
+	// Assert that the required fields are set
+	if iterator.WarcFileReader == nil {
+		panic("WarcFileReader is nil")
+	}
+	if iterator.Records == nil {
+		panic("Result channel is nil")
+	}
+
+	defer close(iterator.Records)
+
+	var currentOffset, previousOffset int64
+	var warcRecord, previousWarcRecord gowarc.WarcRecord
+	var validation, previousValidation *gowarc.Validation
+	var err, previousErr error
+
+	var skippedFirst bool
+
+	var count int
+
+	for {
+		// return if previous record was the last record
+		if err == io.EOF {
+			return
+		}
+
+		// keep track of the previous iteration's values
+		previousWarcRecord = warcRecord
+		previousValidation = validation
+		previousErr = err
+		previousOffset = currentOffset
+
+		// read next record
+		warcRecord, currentOffset, validation, err = iterator.WarcFileReader.Next()
+
+		if !skippedFirst {
+			// we delay sending the first record to be able to calculate record size
+			skippedFirst = true
+			continue
+		}
+
+		record := Record{
+			WarcRecord: previousWarcRecord,
+			Size:       currentOffset - previousOffset,
+			Offset:     previousOffset,
+			Validation: previousValidation,
+			Err:        previousErr,
+		}
+
+		// if record has an error, send it and return
+		if record.Err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case iterator.Records <- record:
+			}
+			return
+		}
+
+		if iterator.Filter != nil && !iterator.Filter.Accept(record.WarcRecord) {
+			continue
+		}
+
+		// keep track of the number of records accepted by the filter
+		count++
+
+		// if there was a Nth record specified, skip until we reach it
+		if iterator.Nth > 0 && count != iterator.Nth {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case iterator.Records <- record:
+			// If there was a Nth record specified, return after sending it
+			if iterator.Nth > 0 {
+				return
+			}
+			// If there was a limit specified, return after limit is reached
+			if iterator.Limit > 0 && count >= iterator.Limit {
+				return
+			}
+		}
+	}
+}

--- a/internal/warc/iterator_test.go
+++ b/internal/warc/iterator_test.go
@@ -1,0 +1,106 @@
+package warc
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/nlnwa/gowarc"
+)
+
+const (
+	testDataDir = "../../testdata"
+)
+
+var testFiles = map[string]string{
+	"empty":              filepath.Join(testDataDir, "empty.warc"),
+	"single-record":      filepath.Join(testDataDir, "single-record.warc"),
+	"samsung-with-error": filepath.Join(testDataDir, "samsung-with-error", "rec-33318048d933-20240317162652059-0.warc.gz"),
+}
+
+var tests = []struct {
+	file         string   // path to WARC file
+	iterator     Iterator // iterator configuration
+	wantCount    int      // expected number of records from iterator
+	wantRecordId string   // expected record id
+}{
+	{
+		file:      testFiles["empty"],
+		wantCount: 0,
+	},
+	{
+		file:      testFiles["single-record"],
+		wantCount: 1,
+	},
+	{
+		file:      testFiles["samsung-with-error"],
+		wantCount: 54,
+	},
+	{
+		file: testFiles["samsung-with-error"],
+		iterator: Iterator{
+			Limit: 50,
+		},
+		wantCount: 50,
+	},
+	{
+		file: testFiles["samsung-with-error"],
+		iterator: Iterator{
+			Nth: 7,
+		},
+		wantCount:    1,
+		wantRecordId: "urn:uuid:60331c1b-c2f4-486a-a14f-bd448ba6e1c7",
+	},
+}
+
+func TestIterator(t *testing.T) {
+	for _, test := range tests {
+		t.Run(filepath.Base(test.file), func(t *testing.T) {
+			// capture test variable from outer scope
+			test := test
+
+			// resolve test file path
+			testFile, err := filepath.Abs(test.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// open WARC file reader
+			warcFileReader, err := gowarc.NewWarcFileReader(testFile, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// create records channel
+			records := make(chan Record)
+
+			// configure iterator
+			test.iterator.Records = records
+			test.iterator.WarcFileReader = warcFileReader
+
+			// run iterator
+			go test.iterator.Iterate(context.Background())
+
+			// count records
+			count := 0
+
+			// iterate over the records channel
+			for record := range records {
+				count++
+
+				if test.wantRecordId != "" {
+					recordId := record.WarcRecord.WarcHeader().GetId(gowarc.WarcRecordID)
+					// assert record id
+					if recordId != test.wantRecordId {
+						t.Errorf("expected record id %s, got %s", test.wantRecordId, recordId)
+					}
+				}
+			}
+
+			// assert number of records from iterator
+			if count != test.wantCount {
+				t.Errorf("expected %d records, got %d", test.wantCount, count)
+			}
+		})
+	}
+}

--- a/testdata/single-record.warc
+++ b/testdata/single-record.warc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fea8d51da95a7115d70eab7b3e8cd4bd8ae3afbe4cecc7cb64cc57b7d999768
+size 154


### PR DESCRIPTION
The [gowarc.WarcFileReader](https://pkg.go.dev/github.com/nlnwa/gowarc#WarcFileReader) does not provide a simple way to get the size of the next record.

This PR introduces an iterator abstraction for iterating over WARC records. In addition to returning the size of each record the iterator encapsulates:
- filtering records
- limiting the number of records
- selecting the nth record

~This PR only includes the implementation of the iterator. Future pull requests will start using it.~
edit: added use cases