### PR TITLE
refactor: use record iterator in subcommands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.warc.gz filter=lfs diff=lfs merge=lfs -text
+*.warc filter=lfs diff=lfs merge=lfs -text

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -1,14 +1,15 @@
 package cat
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/nlnwa/gowarc"
 	"github.com/nlnwa/warchaeology/internal/filter"
 	"github.com/nlnwa/warchaeology/internal/flag"
+	"github.com/nlnwa/warchaeology/internal/warc"
 	"github.com/spf13/viper"
 )
 
@@ -23,100 +24,104 @@ type config struct {
 	showPayload        bool
 }
 
-func listRecords(catConfig *config, fileName string) {
-	warcFileReader, err := gowarc.NewWarcFileReader(fileName, catConfig.offset, gowarc.WithBufferTmpDir(viper.GetString(flag.TmpDir)))
-	defer func() { _ = warcFileReader.Close() }()
+func runCat(catConfig *config) error {
+	warcFileReader, err := gowarc.NewWarcFileReader(catConfig.fileName, catConfig.offset, gowarc.WithBufferTmpDir(viper.GetString(flag.TmpDir)))
 	if err != nil {
-		fmt.Printf("Error opening file: %v\n", err)
-		return
+		return fmt.Errorf("error opening file: %w", err)
 	}
 
-	num := 0
-	count := 0
+	defer func() { _ = warcFileReader.Close() }()
 
-	for {
-		warcRecord, _, _, err := warcFileReader.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %v, rec num: %v, Offset %v\n", err.Error(), strconv.Itoa(count), catConfig.offset)
-			break
-		}
+	records := make(chan warc.Record)
 
-		if !catConfig.filter.Accept(warcRecord) {
-			continue
-		}
+	iterator := warc.Iterator{
+		WarcFileReader: warcFileReader,
+		Filter:         catConfig.filter,
+		Nth:            catConfig.recordNum,
+		Limit:          catConfig.recordCount,
+		Records:        records,
+	}
 
-		// Find record number
-		if catConfig.recordNum > 0 && num < catConfig.recordNum {
-			num++
-			continue
-		}
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-		count++
-		out := os.Stdout
+	go iterator.Iterate(ctx)
 
-		if catConfig.showWarcHeader {
-			// Write WARC record version
-			_, err = fmt.Fprintf(out, "%v\r\n", warcRecord.Version())
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-
-			// Write WARC header
-			_, err = warcRecord.WarcHeader().Write(out)
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-
-			// Write separator
-			_, err = out.WriteString("\r\n")
-			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-			}
-		}
-
-		if catConfig.showProtocolHeader {
-			if headerBlock, ok := warcRecord.Block().(gowarc.ProtocolHeaderBlock); ok {
-				_, err = out.Write(headerBlock.ProtocolHeaderBytes())
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			}
-		}
-
-		if catConfig.showPayload {
-			if payloadBlock, ok := warcRecord.Block().(gowarc.PayloadBlock); ok {
-				reader, err := payloadBlock.PayloadBytes()
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-				_, err = io.Copy(out, reader)
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			} else {
-				reader, err := warcRecord.Block().RawBytes()
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-				_, err = io.Copy(out, reader)
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-				}
-			}
-		}
-
-		// Write end of record separator
-		_, err = out.WriteString("\r\n\r\n")
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-		}
-
-		if catConfig.recordCount > 0 && count >= catConfig.recordCount {
-			break
+	for record := range records {
+		if err := catRecord(record, catConfig); err != nil {
+			return err
 		}
 	}
-	_, _ = fmt.Fprintln(os.Stderr, "Count: ", count)
+	return nil
+}
+
+func catRecord(record warc.Record, catConfig *config) error {
+	out := os.Stdout
+
+	err := record.Err
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error in record at offset %v: %v\n", record.Offset, record.Err)
+		return nil
+	}
+
+	warcRecord := record.WarcRecord
+
+	if catConfig.showWarcHeader {
+		// Write WARC record version
+		_, err = fmt.Fprintf(out, "%v\r\n", warcRecord.Version())
+		if err != nil {
+			return fmt.Errorf("error writing WARC record version: %w", err)
+		}
+
+		// Write WARC header
+		_, err = warcRecord.WarcHeader().Write(out)
+		if err != nil {
+			return fmt.Errorf("error writing WARC header: %w", err)
+		}
+
+		// Write separator
+		_, err = out.WriteString("\r\n")
+		if err != nil {
+			return fmt.Errorf("error writing separator: %w", err)
+		}
+	}
+
+	if catConfig.showProtocolHeader {
+		if headerBlock, ok := warcRecord.Block().(gowarc.ProtocolHeaderBlock); ok {
+			_, err = out.Write(headerBlock.ProtocolHeaderBytes())
+			if err != nil {
+				return fmt.Errorf("error writing protocol header: %w", err)
+			}
+		}
+	}
+
+	if catConfig.showPayload {
+		if payloadBlock, ok := warcRecord.Block().(gowarc.PayloadBlock); ok {
+			reader, err := payloadBlock.PayloadBytes()
+			if err != nil {
+				return fmt.Errorf("error reading payload: %w", err)
+			}
+			_, err = io.Copy(out, reader)
+			if err != nil {
+				return fmt.Errorf("error writing payload: %w", err)
+			}
+		} else {
+			reader, err := warcRecord.Block().RawBytes()
+			if err != nil {
+				return fmt.Errorf("error reading raw bytes of record block: %w", err)
+			}
+			_, err = io.Copy(out, reader)
+			if err != nil {
+				return fmt.Errorf("error writing raw bytes of record block: %w", err)
+			}
+		}
+	}
+
+	// Write end of record separator
+	_, err = os.Stdout.WriteString("\r\n\r\n")
+	if err != nil {
+		return fmt.Errorf("error writing end of record separator: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/cat/cli.go
+++ b/cmd/cat/cli.go
@@ -64,6 +64,6 @@ func parseArgumentsAndCallCat(cmd *cobra.Command, args []string) error {
 		catConfig.showProtocolHeader = true
 		catConfig.showPayload = true
 	}
-	listRecords(catConfig, catConfig.fileName)
-	return nil
+	
+	return runCat(catConfig)
 }

--- a/internal/warc/iterator.go
+++ b/internal/warc/iterator.go
@@ -1,0 +1,114 @@
+package warc
+
+import (
+	"context"
+	"io"
+
+	"github.com/nlnwa/gowarc"
+	"github.com/nlnwa/warchaeology/internal/filter"
+)
+
+// Record represents a WARC record with additional metadata
+type Record struct {
+	Offset     int64
+	Size       int64
+	Err        error
+	WarcRecord gowarc.WarcRecord
+	Validation *gowarc.Validation
+}
+
+// Itetaror is a WARC record iterator
+type Iterator struct {
+	// reader to read WARC records from
+	WarcFileReader *gowarc.WarcFileReader
+
+	// return only the Nth record (0 for all) after applying filter
+	Nth int
+
+	// return at most N records (0 for all) after applying filter
+	Limit int
+
+	// return only records that match the filter
+	Filter *filter.Filter
+
+	// channel to send records to
+	Records chan<- Record
+}
+
+// Iterate reads WARC records from the WARC file reader and sends them to the result channel
+func (iterator Iterator) Iterate(ctx context.Context) {
+	// Assert that the required fields are set
+	if iterator.WarcFileReader == nil {
+		panic("WarcFileReader is nil")
+	}
+	if iterator.Records == nil {
+		panic("Result channel is nil")
+	}
+
+	defer close(iterator.Records)
+
+	var currentOffset, previousOffset int64
+	var warcRecord, previousWarcRecord gowarc.WarcRecord
+	var validation, previousValidation *gowarc.Validation
+	var err, previousErr error
+
+	var skippedFirst bool
+
+	var count int
+
+	for {
+		// return if previous record was the last record
+		if err == io.EOF {
+			return
+		}
+
+		// keep track of the previous iteration's values
+		previousWarcRecord = warcRecord
+		previousValidation = validation
+		previousErr = err
+		previousOffset = currentOffset
+
+		// read next record
+		warcRecord, currentOffset, validation, err = iterator.WarcFileReader.Next()
+
+		if !skippedFirst {
+			// we delay sending the first record to be able to calculate record size
+			skippedFirst = true
+			continue
+		}
+
+		record := Record{
+			WarcRecord: previousWarcRecord,
+			Size:       currentOffset - previousOffset,
+			Offset:     previousOffset,
+			Validation: previousValidation,
+			Err:        previousErr,
+		}
+
+		if iterator.Filter != nil && !iterator.Filter.Accept(record.WarcRecord) {
+			continue
+		}
+
+		// keep track of the number of records accepted by the filter
+		count++
+
+		// if there was a Nth record specified, skip until we reach it
+		if iterator.Nth > 0 && count != iterator.Nth {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case iterator.Records <- record:
+			// If there was a Nth record specified, return after sending it
+			if iterator.Nth > 0 {
+				return
+			}
+			// If there was a limit specified, return after limit is reached
+			if iterator.Limit > 0 && count >= iterator.Limit {
+				return
+			}
+		}
+	}
+}

--- a/internal/warc/iterator.go
+++ b/internal/warc/iterator.go
@@ -85,8 +85,12 @@ func (iterator Iterator) Iterate(ctx context.Context) {
 			Err:        previousErr,
 		}
 
-		if iterator.Filter != nil && !iterator.Filter.Accept(record.WarcRecord) {
-			continue
+		// TODO decide what should happen when a record with an error is encountered
+		// as of now, the record is treated as if passing the filter
+		if record.WarcRecord != nil {
+			if iterator.Filter != nil && !iterator.Filter.Accept(record.WarcRecord) {
+				continue
+			}
 		}
 
 		// keep track of the number of records accepted by the filter

--- a/internal/warc/iterator_test.go
+++ b/internal/warc/iterator_test.go
@@ -1,0 +1,106 @@
+package warc
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/nlnwa/gowarc"
+)
+
+const (
+	testDataDir = "../../test-data"
+)
+
+var testFiles = map[string]string{
+	"empty":              filepath.Join(testDataDir, "empty.warc"),
+	"single-record":      filepath.Join(testDataDir, "single-record.warc"),
+	"samsung-with-error": filepath.Join(testDataDir, "samsung-with-error", "rec-33318048d933-20240317162652059-0.warc.gz"),
+}
+
+var tests = []struct {
+	file         string   // path to WARC file
+	iterator     Iterator // iterator configuration
+	wantCount    int      // expected number of records from iterator
+	wantRecordId string   // expected record id
+}{
+	{
+		file:      testFiles["empty"],
+		wantCount: 0,
+	},
+	{
+		file:      testFiles["single-record"],
+		wantCount: 1,
+	},
+	{
+		file:      testFiles["samsung-with-error"],
+		wantCount: 54,
+	},
+	{
+		file: testFiles["samsung-with-error"],
+		iterator: Iterator{
+			Limit: 50,
+		},
+		wantCount: 50,
+	},
+	{
+		file: testFiles["samsung-with-error"],
+		iterator: Iterator{
+			Nth: 7,
+		},
+		wantCount:    1,
+		wantRecordId: "urn:uuid:60331c1b-c2f4-486a-a14f-bd448ba6e1c7",
+	},
+}
+
+func TestIterator(t *testing.T) {
+	for _, test := range tests {
+		t.Run(filepath.Base(test.file), func(t *testing.T) {
+			// capture test variable from outer scope
+			test := test
+
+			// resolve test file path
+			testFile, err := filepath.Abs(test.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// open WARC file reader
+			warcFileReader, err := gowarc.NewWarcFileReader(testFile, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// create records channel
+			records := make(chan Record)
+
+			// configure iterator
+			test.iterator.Records = records
+			test.iterator.WarcFileReader = warcFileReader
+
+			// run iterator
+			go test.iterator.Iterate(context.Background())
+
+			// count records
+			count := 0
+
+			// iterate over the records channel
+			for record := range records {
+				count++
+
+				if test.wantRecordId != "" {
+					recordId := record.WarcRecord.WarcHeader().GetId(gowarc.WarcRecordID)
+					// assert record id
+					if recordId != test.wantRecordId {
+						t.Errorf("expected record id %s, got %s", test.wantRecordId, recordId)
+					}
+				}
+			}
+
+			// assert number of records from iterator
+			if count != test.wantCount {
+				t.Errorf("expected %d records, got %d", test.wantCount, count)
+			}
+		})
+	}
+}

--- a/test-data/single-record.warc
+++ b/test-data/single-record.warc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fea8d51da95a7115d70eab7b3e8cd4bd8ae3afbe4cecc7cb64cc57b7d999768
+size 154


### PR DESCRIPTION
Unify the iteration of records to avoid duplication and make the code testable.