### PR TITLE
test: add initial test data for `nedlib`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.warc.gz filter=lfs diff=lfs merge=lfs -text
+test-data/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5 filter=lfs diff=lfs merge=lfs -text
+test-data/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5 filter=lfs diff=lfs merge=lfs -text
+*.meta filter=lfs diff=lfs merge=lfs -text

--- a/cmd/convert/nedlib/nedlib_test.go
+++ b/cmd/convert/nedlib/nedlib_test.go
@@ -1,0 +1,29 @@
+package nedlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nlnwa/warchaeology/internal/filewalker"
+	"github.com/spf13/afero"
+)
+
+type walker []string
+
+func (fileWalker *walker) dummyWalkFunction(_ afero.Fs, path string) filewalker.Result {
+	*fileWalker = append(*fileWalker, path)
+	return filewalker.NewResult(path)
+}
+
+func TestConvert(t *testing.T) {
+	testDataDir := filepath.Join("..", "..", "test-data")
+	nedlibDir := filepath.Join(testDataDir, "nedlib", "nb-image")
+
+	fileWalker := walker{}
+	config := &conf{}
+	config.files = []string{nedlibDir}
+	_, err := filewalker.New([]string{nedlibDir}, false, false, []string{}, 1, fileWalker.dummyWalkFunction)
+	if err != nil {
+		t.Errorf("error creating file walker, original error: '%v'", err)
+	}
+}

--- a/test-data/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5
+++ b/test-data/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c66ee5928ade485e93c3675e5da9be5c28f862ecfdff643df377bdd4ed19219e
+size 10920

--- a/test-data/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5.meta
+++ b/test-data/nedlib/nb-image/b863a630196bce1a15ca86b40f34a2d5.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8feaee4b6c6c67f2d3af19592dcb358643350eb0651f3109d0d3e409af0d53d8
+size 443

--- a/test-data/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5
+++ b/test-data/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20640945a7f3240d47c48eff1d8fa43505109a6e75e1486a789b978fb4eb1fa5
+size 1802

--- a/test-data/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5.meta
+++ b/test-data/nedlib/nb-image/e4a2d28bdf4c38b8f6f291f7c8c958d5.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162920fed7bdc512f4e7d929dcdaf39510bac1d3fc4082497355d3111433a7fa
+size 455


### PR DESCRIPTION
This commit adds initial test data for the
`nedlib` format. The test data was provided by the National Library of Norway.

A minimal test was added to use this test data.