### PR TITLE
fix: set `hugo` version to `1.24.1`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.124.1'
           extended: true
 
       - name: Build


### PR DESCRIPTION
The latest version of `hugo` breaks the building
of the documentation with the following error:

```
ERROR render of "taxonomy" failed:
"/home/runner/work/warchaeology/warchaeology/docs/themes/ace-documentation/layouts/_default/baseof.html:3:8":
execute of template failed: template:
_default/list.html:3:8: executing
"_default/list.html" at <partial "head.html" .>:
error calling partial: execute of template failed:
html/template:partials/head.html:29:20: no such
template "_internal/google_analytics_async.html"
ERROR render of "section" failed:
"/home/runner/work/warchaeology/warchaeology/docs/themes/ace-documentation/layouts/_default/baseof.html:3:8":
execute of template failed: template:
_default/list.html:3:8: executing
"_default/list.html" at <partial "head.html" .>:
error calling partial: execute of template failed:
html/template:partials/head.html:29:20: no such
template "_internal/google_analytics_async.html"
ERROR render of "page" failed:
"/home/runner/work/warchaeology/warchaeology/docs/themes/ace-documentation/layouts/_default/baseof.html:3:8":
execute of template failed: template:
cmd/single.html:3:8: executing "cmd/single.html"
at <partial "head.html" .>: error calling partial:
execute of template failed:
html/template:partials/head.html:29:20: no such
template "_internal/google_analytics_async.html"
Total in 22 ms
Error: error building site: render:
failed to render pages: render of "home" failed:
"/home/runner/work/warchaeology/warchaeology/docs/themes/ace-documentation/layouts/_default/baseof.html:3:8":
execute of template failed: template:
index.html:3:8: executing "index.html" at <partial
"head.html" .>: error calling partial: execute of
template failed:
html/template:partials/head.html:29:20: no such
template "_internal/google_analytics_async.html"
```

By setting the version to `1.24.1` we can avoid
this error until we figure out how to fix the new
error.