### PR TITLE
fix: parse broken rfc1123 format

### DIFF
--- a/nedlibreader/time.go
+++ b/nedlibreader/time.go
@@ -68,6 +68,10 @@ func parseTime(dateString string) (t time.Time, err error) {
 	if err == nil {
 		return
 	}
+	t, err = parseRFC1123BrokenYear(dateString)
+	if err == nil {
+		return
+	}
 	return time.Time{}, fmt.Errorf("failed to parse string as time.Time: '%s'", dateString)
 }
 
@@ -100,6 +104,12 @@ func parseRFC850BrokenYear(value string) (time.Time, error) {
 	// Replace Jul-103 With Jul-03
 	value = regexp.MustCompile(`([A-Za-z]{3}-)1(\d{2})`).ReplaceAllString(value, "${1}${2}")
 	return time.Parse(time.RFC850, value)
+}
+
+func parseRFC1123BrokenYear(value string) (time.Time, error) {
+	// Replace 31 Jul 103 With 31 Jul 2003
+	value = regexp.MustCompile(`(\d{2} [A-Za-z]{3}) 1(\d{2})`).ReplaceAllString(value, "${1} 20${2}")
+	return time.Parse(time.RFC1123, value)
 }
 
 // parse date and time string on the format: "lø, 19 jul 2003 04:45:41 CET" to a time.Time

--- a/nedlibreader/time_test.go
+++ b/nedlibreader/time_test.go
@@ -21,6 +21,7 @@ const (
 	RFC1123_NO_LEADING_ZERO      = "RFC1123_NO_LEADING_ZERO"
 	RFC1123_SECONDS_OUT_OF_RANGE = "RFC1123_SECONDS_OUT_OF_RANGE"
 	RFC1123_NORSK                = "RFC1123_NORSK"
+	RFC1123_BROKEN_YEAR          = "RFC1123_BROKEN_YEAR"
 	RFC822                       = "RFC822"
 	RFC822Z                      = "RFC822Z"
 	RFC850                       = "RFC850"
@@ -38,6 +39,7 @@ var timeParseFuncs = map[string]func(string) (time.Time, error){
 	RFC1123Z:                     func(value string) (time.Time, error) { return time.Parse(time.RFC1123Z, value) },
 	RFC1123_NORSK:                parseCustomNorwegianTime,
 	RFC1123_SECONDS_OUT_OF_RANGE: parseRFC1123SecondsOutOfRange,
+	RFC1123_BROKEN_YEAR:          parseRFC1123BrokenYear,
 	RFC850:                       func(value string) (time.Time, error) { return time.Parse(time.RFC850, value) },
 	RFC850_BROKEN_YEAR:           parseRFC850BrokenYear,
 	RFC822:                       func(value string) (time.Time, error) { return time.Parse(time.RFC822, value) },
@@ -100,6 +102,10 @@ var timeTests = map[string][]struct {
 		{"Sat, 2 Aug 2003 03:41:01 GMT", time.Date(2003, time.August, 2, 3, 41, 1, 0, time.UTC)},
 		{"Sun, 3 Aug 2003 03:34:00 GMT", time.Date(2003, time.August, 3, 3, 34, 0, 0, time.UTC)},
 		{"Sun, 3 Aug 2003 05:43:49 CES", time.Date(2003, time.August, 3, 7, 43, 49, 0, locCET)},
+	},
+	RFC1123_BROKEN_YEAR: {
+		{"Thu, 31 Jul 103 13:00:03 GMT", time.Date(2003, time.July, 31, 13, 0, 3, 0, time.UTC)},
+		{"Thu, 31 Jul 103 16:45:34 GMT", time.Date(2003, time.July, 31, 16, 45, 34, 0, time.UTC)},
 	},
 	RFC1123_SECONDS_OUT_OF_RANGE: {
 		{"Thu, 17 Jul 2003 12:15:60 GMT", time.Date(2003, time.July, 17, 12, 15, 60, 0, time.UTC)},


### PR DESCRIPTION
This PR adds special handling of a specific occurence of RFC1123 timestamp  with broken year.