### PR TITLE
adding possible variations of hash algo

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -375,20 +375,20 @@ func (reader *teeReader) Hash() string {
 func NewCountingReader(ioReader io.Reader, hashFunction string) io.Reader {
 	countingReader := &countingReader{Reader: ioReader}
 	switch hashFunction {
-        case "md5":
-                countingReader.hash = crypto.MD5.New()
-        case "sha1":
-                countingReader.hash = crypto.SHA1.New()
-        case "sha-1":
-                countingReader.hash = crypto.SHA1.New()
-        case "sha256":
-                countingReader.hash = crypto.SHA256.New()
-        case "sha-256":
-                countingReader.hash = crypto.SHA256.New()
-        case "sha512":
-                countingReader.hash = crypto.SHA512.New()
-        case "sha-512":
-                countingReader.hash = crypto.SHA512.New()
+	case "md5":
+		countingReader.hash = crypto.MD5.New()
+	case "sha1":
+		countingReader.hash = crypto.SHA1.New()
+	case "sha-1":
+		countingReader.hash = crypto.SHA1.New()
+	case "sha256":
+		countingReader.hash = crypto.SHA256.New()
+	case "sha-256":
+		countingReader.hash = crypto.SHA256.New()
+	case "sha512":
+		countingReader.hash = crypto.SHA512.New()
+	case "sha-512":
+		countingReader.hash = crypto.SHA512.New()
 	}
 	return countingReader
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -375,14 +375,20 @@ func (reader *teeReader) Hash() string {
 func NewCountingReader(ioReader io.Reader, hashFunction string) io.Reader {
 	countingReader := &countingReader{Reader: ioReader}
 	switch hashFunction {
-	case "md5":
-		countingReader.hash = crypto.MD5.New()
-	case "sha1":
-		countingReader.hash = crypto.SHA1.New()
-	case "sha256":
-		countingReader.hash = crypto.SHA256.New()
-	case "sha512":
-		countingReader.hash = crypto.SHA512.New()
+        case "md5":
+                countingReader.hash = crypto.MD5.New()
+        case "sha1":
+                countingReader.hash = crypto.SHA1.New()
+        case "sha-1":
+                countingReader.hash = crypto.SHA1.New()
+        case "sha256":
+                countingReader.hash = crypto.SHA256.New()
+        case "sha-256":
+                countingReader.hash = crypto.SHA256.New()
+        case "sha512":
+                countingReader.hash = crypto.SHA512.New()
+        case "sha-512":
+                countingReader.hash = crypto.SHA512.New()
 	}
 	return countingReader
 }


### PR DESCRIPTION
Webrecorder chrome addon https://github.com/webrecorder/archiveweb.page creates (/has created?) lines like:
```
WARC-Payload-Digest: sha-256:1e85ec81b9800b4c443d39caca0d0926089a3ac201120db1ceb45b93789480b8
```

It makes this validation script explode. Also the script stops running and the report doesn't show all the records of the warc.

I thought this kind of change could be useful (though: no clue if any "sha-1" or "sha-512" strings in the wild), as there doesn't seem to be any "whitelist" for this particular string denoting the hash in WARC format.

TEST: Compiled and ran this, seemed to work fine!