### PR TITLE
Fix dedup command not using record option flags

### DIFF
--- a/cmd/convert/warc/warc.go
+++ b/cmd/convert/warc/warc.go
@@ -86,34 +86,8 @@ func (f ConvertWarcFlags) ToConvertWarcOptions() (*ConvertWarcOptions, error) {
 	warcRecordOptions := []gowarc.WarcRecordOption{
 		gowarc.WithVersion(wwc.WarcVersion),
 	}
-	if f.RepairFlags.Repair() {
-		warcRecordOptions = append(warcRecordOptions,
-			gowarc.WithSyntaxErrorPolicy(gowarc.ErrWarn),
-			gowarc.WithSpecViolationPolicy(gowarc.ErrWarn),
-			gowarc.WithAddMissingDigest(true),
-			gowarc.WithFixSyntaxErrors(true),
-			gowarc.WithFixDigest(true),
-			gowarc.WithAddMissingContentLength(true),
-			gowarc.WithAddMissingRecordId(true),
-			gowarc.WithFixContentLength(true),
-			gowarc.WithFixWarcFieldsBlockErrors(true),
-		)
-	} else {
-		warcRecordOptions = append(warcRecordOptions,
-			gowarc.WithSyntaxErrorPolicy(gowarc.ErrWarn),
-			gowarc.WithSpecViolationPolicy(gowarc.ErrWarn),
-			gowarc.WithAddMissingDigest(false),
-			gowarc.WithFixSyntaxErrors(false),
-			gowarc.WithFixDigest(false),
-			gowarc.WithAddMissingContentLength(false),
-			gowarc.WithAddMissingRecordId(false),
-			gowarc.WithFixContentLength(false),
-			gowarc.WithFixWarcFieldsBlockErrors(false),
-		)
-	}
-
-	overrideRecordOptions := f.WarcRecordOptionFlags.ToWarcRecordOptions()
-	warcRecordOptions = append(warcRecordOptions, overrideRecordOptions...)
+	warcRecordOptions = append(warcRecordOptions, f.RepairFlags.ToWarcRecordOptions()...)
+	warcRecordOptions = append(warcRecordOptions, f.WarcRecordOptionFlags.ToWarcRecordOptions()...)
 
 	fileWalker, err := f.FileWalkerFlags.ToFileWalker()
 	if err != nil {

--- a/cmd/dedup/dedup.go
+++ b/cmd/dedup/dedup.go
@@ -137,30 +137,10 @@ func (f DedupFlags) ToDedupOptions() (*DedupOptions, error) {
 	}
 
 	warcRecordOptions := []gowarc.WarcRecordOption{
-		gowarc.WithBufferTmpDir(f.WarcRecordOptionFlags.TmpDir()),
 		gowarc.WithBufferMaxMemBytes(f.BufferMaxMem()),
-		gowarc.WithSyntaxErrorPolicy(gowarc.ErrWarn),
-		gowarc.WithSpecViolationPolicy(gowarc.ErrWarn),
-		gowarc.WithAddMissingDigest(true),
-		gowarc.WithAddMissingContentLength(true),
 	}
-
-	if f.RepairFlags.Repair() {
-		warcRecordOptions = append(warcRecordOptions,
-			gowarc.WithFixSyntaxErrors(true),
-			gowarc.WithFixDigest(true),
-			gowarc.WithAddMissingRecordId(true),
-			gowarc.WithFixContentLength(true),
-			gowarc.WithFixWarcFieldsBlockErrors(true),
-		)
-	} else {
-		warcRecordOptions = append(warcRecordOptions,
-			gowarc.WithFixSyntaxErrors(false),
-			gowarc.WithFixDigest(false),
-			gowarc.WithAddMissingRecordId(false),
-			gowarc.WithFixContentLength(false),
-		)
-	}
+	warcRecordOptions = append(warcRecordOptions, f.RepairFlags.ToWarcRecordOptions()...)
+	warcRecordOptions = append(warcRecordOptions, f.WarcRecordOptionFlags.ToWarcRecordOptions()...)
 
 	fileWalker, err := f.FileWalkerFlags.ToFileWalker()
 	if err != nil {

--- a/cmd/internal/flag/repair_flags.go
+++ b/cmd/internal/flag/repair_flags.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"github.com/nlnwa/gowarc/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -13,10 +14,38 @@ const (
 type RepairFlags struct {
 }
 
-func (u RepairFlags) AddFlags(cmd *cobra.Command) {
+func (r RepairFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP(Repair, "R", false, RepairHelp)
 }
 
-func (u RepairFlags) Repair() bool {
+func (r RepairFlags) Repair() bool {
 	return viper.GetBool(Repair)
+}
+
+func (r RepairFlags) ToWarcRecordOptions() []gowarc.WarcRecordOption {
+	if r.Repair() {
+		return []gowarc.WarcRecordOption{
+			gowarc.WithSyntaxErrorPolicy(gowarc.ErrWarn),
+			gowarc.WithSpecViolationPolicy(gowarc.ErrWarn),
+			gowarc.WithAddMissingDigest(true),
+			gowarc.WithFixSyntaxErrors(true),
+			gowarc.WithFixDigest(true),
+			gowarc.WithAddMissingContentLength(true),
+			gowarc.WithAddMissingRecordId(true),
+			gowarc.WithFixContentLength(true),
+			gowarc.WithFixWarcFieldsBlockErrors(true),
+		}
+	} else {
+		return []gowarc.WarcRecordOption{
+			gowarc.WithSyntaxErrorPolicy(gowarc.ErrWarn),
+			gowarc.WithSpecViolationPolicy(gowarc.ErrWarn),
+			gowarc.WithAddMissingDigest(false),
+			gowarc.WithFixSyntaxErrors(false),
+			gowarc.WithFixDigest(false),
+			gowarc.WithAddMissingContentLength(false),
+			gowarc.WithAddMissingRecordId(false),
+			gowarc.WithFixContentLength(false),
+			gowarc.WithFixWarcFieldsBlockErrors(false),
+		}
+	}
 }


### PR DESCRIPTION
This PR makes sure the dedup command actually use the record option flags and aligns the repair options with the warc-to-warc conversion.